### PR TITLE
Make node_module imports available to Stylus.

### DIFF
--- a/lib/files/stylesheet.js
+++ b/lib/files/stylesheet.js
@@ -38,7 +38,7 @@ module.exports = class Stylesheet extends File {
     if (this.isStylus) {
        output = stylus(this.input)
         .set('filename', this.path.full)
-        .set('paths', [path.dirname(this.path.full)])
+        .set('paths', [path.dirname(this.path.full),'node_modules/'])
         .render()
       return done(null, output)
     }


### PR DESCRIPTION
Lots of stylus libs are distributed through stylus which is an ideal delivery platform. This exposes the node_modules folder to the stylus importer.