### PR TITLE
upgrade to newer marky-markdown with node 6 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "lil-env-thing": "^1.0.0",
     "lobars": "^1.2.0",
     "lodash": "^4.0.0",
-    "marky-markdown": "^6.0.1",
+    "marky-markdown": "^8.1.0",
     "minimist": "^1.2.0",
     "morgan": "^1.6.1",
     "myth": "^1.5.0",


### PR DESCRIPTION
Fixes https://github.com/zeke/jus/issues/29