### PR TITLE
Do not attempt to handle SVG fonts as images

### DIFF
--- a/lib/jus.js
+++ b/lib/jus.js
@@ -25,6 +25,9 @@ module.exports = function jus (sourceDir, targetDir) {
     var type = extensions[ext]
     if (fileTypes.layout.test(filename)) type = 'layout'
     if (filename.endsWith('.min.js')) type = 'unknown'
+    if (ext === 'svg') {
+      if (fs.readFileSync(filename, 'utf8').includes('</font>')) type = 'unknown'
+    }
     if (!type) type = 'unknown'
 
     file = new fileTypes[type](filename, sourceDir, targetDir)

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "handlebars": "^4.0.5",
     "href-type": "^1.0.0",
     "html-frontmatter": "^1.6.0",
-    "image-size": "^0.4.0",
+    "image-size": "^0.5.0",
     "inflection": "^1.8.0",
     "js-yaml": "^3.4.6",
     "less": "^2.6.1",


### PR DESCRIPTION
This addresses #48. In an earlier attempt to solve this, when I thought that images themselves were not being properly handled, I bumped the version of the `image-size` dependency - I've left that change in since it didn't break anything and it's good to keep dependencies up to date, but the old version worked just fine if we want to leave it alone.