### PR TITLE
17 datafile refresh in page object

### DIFF
--- a/lib/files/datafile.js
+++ b/lib/files/datafile.js
@@ -12,7 +12,11 @@ module.exports = class datafile extends File {
 
   squeeze() {
     this.squeezed = false
-    if (this.isJSON) this.data = require(this.path.full)
+    if (this.isJSON) {
+      // if not the first time, delete cache
+      if (this.data) delete require.cache[require.resolve(this.path.full)]
+      this.data = require(this.path.full)
+    }
     if (this.isYML) this.data = yaml.safeLoad(fs.readFileSync(this.path.full, 'utf8'))
     this.squeezed = true
   }

--- a/test/fixtures/always-changing-data.json
+++ b/test/fixtures/always-changing-data.json
@@ -1,0 +1,3 @@
+{
+  "today": "rainy"
+}

--- a/test/fixtures/always-changing-data.json
+++ b/test/fixtures/always-changing-data.json
@@ -1,3 +1,3 @@
 {
-  "today": "rainy"
+  "today": "sunny"
 }

--- a/test/server.js
+++ b/test/server.js
@@ -249,15 +249,13 @@ describe('server', function () {
     var updated
 
     before(done => {
-      var different
-
       supertest(server)
         .get('/api/files')
         .end((err, res) => {
           context = res.body
           datafile = context.datafiles.filter(file => file.href === DATAFILE_HREF)[0]
           original = datafile.data.today
-          original === 'sunny' ? different = 'rainy' : different = 'sunny'
+          var different = original === 'sunny' ? 'rainy' : 'sunny'
           fs.writeJsonSync(DATAFILE_PATH, {today: different})
           return done()
         })

--- a/test/server.js
+++ b/test/server.js
@@ -1,6 +1,7 @@
 /* globals before, describe, it */
 
 const expect      = require('chai').expect
+const fs          = require('fs-extra')
 const path        = require('upath')
 const supertest   = require('supertest')
 const cheerio     = require('cheerio')
@@ -229,6 +230,69 @@ describe('server', function () {
 
     it('has response text containing the missing href', function(){
       expect(text).to.include(MISSING_HREF)
+    })
+
+  })
+
+  // Steps to test refresh datafile in page object
+  // (server is running so squeezing files happens immediately after updating them)
+  // Inquire 'page' object to obtain actual data and save as 'original'
+  // Update 'always-changing-data.json' file with different data
+  // Cycle inquiring 'page' object until 'squeezed' to obtain updated data as 'updated'
+  // Assert that they are different
+  describe('Refresh datafile in page object', function(){
+    const DATAFILE_HREF = '/always-changing-data.json'
+    const DATAFILE_PATH = path.resolve(__dirname, 'fixtures', '.' + DATAFILE_HREF)
+    var context
+    var datafile
+    var original
+    var updated
+
+    before(done => {
+      var different
+
+      supertest(server)
+        .get('/api/files')
+        .end((err, res) => {
+          context = res.body
+          datafile = context.datafiles.filter(file => file.href === DATAFILE_HREF)[0]
+          original = datafile.data.today
+          original === 'sunny' ? different = 'rainy' : different = 'sunny'
+          fs.writeJsonSync(DATAFILE_PATH, {today: different})
+          return done()
+        })
+    })
+
+    it('got valid original data', function(){
+      datafile = context.datafiles.filter(file => file.href === DATAFILE_HREF)[0]
+      updated = datafile.data.today
+      expect(['sunny', 'rainy']).to.include(updated)
+    })
+
+    describe('GET data from updated (and squeezed) datafile', function(){
+
+      // Polls `datafile.squeezed` every 1s
+      var check = function(done) {
+        supertest(server)
+          .get('/api/files')
+          .end((err, res) => {
+            context = res.body
+            datafile = context.datafiles.filter(file => file.href === DATAFILE_HREF)[0]
+            if (datafile.squeezed) done();
+            else setTimeout( function(){ check(done) }, 1000 );
+          })
+      }
+
+      before(function( done ){
+        check( done );
+      });
+
+      it('got valid updated data (and different than the original)', function(){
+        datafile = context.datafiles.filter(file => file.href === DATAFILE_HREF)[0]
+        updated = datafile.data.today
+        expect(['sunny', 'rainy']).to.include(updated)
+        expect(updated).to.not.equal(original)
+      })
     })
 
   })

--- a/test/server.js
+++ b/test/server.js
@@ -265,8 +265,7 @@ describe('server', function () {
 
     it('got valid original data', function(){
       datafile = context.datafiles.filter(file => file.href === DATAFILE_HREF)[0]
-      updated = datafile.data.today
-      expect(['sunny', 'rainy']).to.include(updated)
+      expect(['sunny', 'rainy']).to.include(original)
     })
 
     describe('GET data from updated (and squeezed) datafile', function(){

--- a/test/server.js
+++ b/test/server.js
@@ -286,7 +286,6 @@ describe('server', function () {
       });
 
       it('got valid updated data (and different than the original)', function(){
-        datafile = context.datafiles.filter(file => file.href === DATAFILE_HREF)[0]
         updated = datafile.data.today
         expect(['sunny', 'rainy']).to.include(updated)
         expect(updated).to.not.equal(original)

--- a/test/server.js
+++ b/test/server.js
@@ -264,7 +264,6 @@ describe('server', function () {
     })
 
     it('got valid original data', function(){
-      datafile = context.datafiles.filter(file => file.href === DATAFILE_HREF)[0]
       expect(['sunny', 'rainy']).to.include(original)
     })
 


### PR DESCRIPTION
Closes #17

The problem was the `require` cache.
When squeezing a datafile, it was not "reading" new changes in file.
The solution was to delete `require.cache`

It has isolated commits for an easy way to **test the test**.
The first commit only includes the test so "it fails" and that is good because that means that "it works".
Now, you can see that later commits pass the test.

**From comments in test code**  
```
  // Steps to test refresh datafile in page object
  // (server is running so squeezing files happens immediately after updating them)
  // Inquire 'page' object to obtain actual data and save as 'original'
  // Update 'always-changing-data.json' file with different data
  // Cycle inquiring 'page' object until 'squeezed' to obtain updated data as 'updated'
  // Assert that they are different
```