### PR TITLE
Keep file.squeezed false to avoid updating races

### DIFF
--- a/lib/jus.js
+++ b/lib/jus.js
@@ -49,7 +49,7 @@ module.exports = function jus (sourceDir, targetDir) {
 
   function tryToFinish() {
     if (files.some(file => !file.squeezed)) return
-    // After initial file squeeze, the 'squeezed' semaphore should be set false
+    // After initial file squeeze, the 'squeezed' flag should be set false
     // to avoid any race condition at file updates
     files.forEach(file => file.squeezed = false)
     emitter.emit('squeezed', contextualize(files))

--- a/lib/jus.js
+++ b/lib/jus.js
@@ -49,6 +49,9 @@ module.exports = function jus (sourceDir, targetDir) {
 
   function tryToFinish() {
     if (files.some(file => !file.squeezed)) return
+    // After initial file squeeze, the 'squeezed' semaphore should be set false
+    // to avoid any race condition at file updates
+    files.forEach(file => file.squeezed = false)
     emitter.emit('squeezed', contextualize(files))
     clearInterval(tryToFinishInterval)
   }

--- a/test/fixtures/always-changing-data.json
+++ b/test/fixtures/always-changing-data.json
@@ -1,3 +1,3 @@
 {
-  "today": "sunny"
+  "today": "rainy"
 }

--- a/test/server.js
+++ b/test/server.js
@@ -274,7 +274,11 @@ describe('server', function () {
           .end((err, res) => {
             context = res.body
             datafile = context.datafiles.filter(file => file.href === DATAFILE_HREF)[0]
-            if (datafile.squeezed) done();
+            if (datafile.squeezed) {
+              // Keep the 'squeezed' semaphore false to avoid any race condition
+              datafile.squeezed = false
+              done()
+            }
             else setTimeout( function(){ check(done) }, 1000 );
           })
       }

--- a/test/server.js
+++ b/test/server.js
@@ -275,7 +275,7 @@ describe('server', function () {
             context = res.body
             datafile = context.datafiles.filter(file => file.href === DATAFILE_HREF)[0]
             if (datafile.squeezed) {
-              // Keep the 'squeezed' semaphore false to avoid any race condition
+              // Keep the 'squeezed' flag false to avoid any race condition
               datafile.squeezed = false
               done()
             }


### PR DESCRIPTION
This could be the solution for the datafile refresh test behavior.

The main idea is that instead of using a state (meaning true or false) use a transition (meaning, from false to true).

This way, there is not possible race condition because it is a transition what we are looking for (not a state).

![jusrefreshtest-02](https://cloud.githubusercontent.com/assets/4935817/22812723/0a337cbc-ef0c-11e6-95ca-582cc1c26c91.png)

It is kind of an easy solution because there is only one `if` about `file.squeezed` in all the code.

....well two places, counting the Refresh test.